### PR TITLE
Added name to fetchurl statement when downloading via HTTP

### DIFF
--- a/lib/packagefetcher/http.js
+++ b/lib/packagefetcher/http.js
@@ -55,6 +55,7 @@ function fetchMetaDataFromHTTP(dependencyName, versionSpec, callback) {
                     src: new nijs.NixFunInvocation({
                         funExpr: new nijs.NixExpression("fetchurl"),
                         paramExpr: {
+                            name: packageObj.name + "-" + packageObj.version + ".tar.gz",
                             url: new nijs.NixURL(parsedUrl.href),
                             sha256: hash
                         }


### PR DESCRIPTION
Resolves a build issue when the URL does not end in .tar.gz.
