### PR TITLE
Reengineering

### DIFF
--- a/lib/generator/collection.js
+++ b/lib/generator/collection.js
@@ -9,6 +9,7 @@ var generate = require('./index.js');
  * Generates a registry Nix expression from a collection of NPM dependendency specifications.
  *
  * @param {String} baseDir Directory in which the referrer's package.json configuration resides
+ * @param {String} outputDir Directory in which nix expression will be written
  * @param {Object} collection An array of strings or objects
  * @param {Boolean} linkDependencies Indicates whether to symlink the dependencies instead of copying them
  * @param {String} registryURL URL of the NPM registry
@@ -16,7 +17,7 @@ var generate = require('./index.js');
  *     If an error occurs, the error parameter is set to contain the error
  *     If the operation succeeds, it returns a string containing the registry expression containing the packages and all its dependencies
  */
-function collectionToRegistryExpr(baseDir, collection, linkDependencies, registryURL, callback) {
+function collectionToRegistryExpr(baseDir, outputDir, collection, linkDependencies, registryURL, callback) {
     var registry = new Registry(registryURL, linkDependencies);
     var i;
 
@@ -33,14 +34,14 @@ function collectionToRegistryExpr(baseDir, collection, linkDependencies, registr
     
         switch(typeof dependency) {
             case "string":
-                registry.addDependencyClosure(baseDir, dependency, "latest", callback); // A string element means that we should take the latest corresponding version
+                registry.addDependencyClosure(baseDir, outputDir, dependency, "latest", callback); // A string element means that we should take the latest corresponding version
                 break;
             case "object":
                 slasp.fromEach(function(callback) { // Objects have a version specification for each package
                     callback(null, dependency);
                 }, function(dependencyName, callback) {
                     var versionSpec = dependency[dependencyName];
-                    registry.addDependencyClosure(baseDir, dependencyName, versionSpec, callback);
+                    registry.addDependencyClosure(baseDir, outputDir, dependencyName, versionSpec, callback);
                 }, callback);
                 break;
             default:

--- a/lib/generator/package.js
+++ b/lib/generator/package.js
@@ -8,6 +8,7 @@ var generate = require('./index.js');
  * Generates a registry Nix expression from a package.json file.
  *
  * @param {String} baseDir Directory in which the referrer's package.json configuration resides
+ * @param {String} outputDir Directory in which the expression will be written
  * @param {Object} packageObj Configuration of a Node.js package
  * @param {Boolean} production Indicates whether to deploy the package in production mode
  * @param {Boolean} linkDependencies Indicates whether to symlink the dependencies instead of copying them
@@ -16,11 +17,11 @@ var generate = require('./index.js');
  *     If an error occurs, the error parameter is set to contain the error
  *     If the operation succeeds, it returns a string containing the registry expression containing the package and all its dependencies
  */
-function packageObjectToRegistryExpr(baseDir, packageObj, production, linkDependencies, registryURL, callback) {
+function packageObjectToRegistryExpr(baseDir, outputDir, packageObj, production, linkDependencies, registryURL, callback) {
     var src = new nijs.NixFile({ value: "./." });
     var registry = new Registry(registryURL, linkDependencies);
     
-    registry.addPackage(baseDir, packageObj, src, production, function(err) {
+    registry.addPackage(baseDir, outputDir, packageObj, src, production, function(err) {
         if(err) {
             callback("Cannot generate registry expression: "+err);
         } else {

--- a/lib/npm2nix.js
+++ b/lib/npm2nix.js
@@ -60,11 +60,12 @@ function npmToNix(inputJSON, outputNix, compositionNix, nodeEnvNix, production, 
         function(callback) {
             if(typeof obj == "object" && obj !== null) {
                 var baseDir = path.dirname(inputJSON);
+                var outputDir = path.dirname(outputNix);
                 
                 if(Array.isArray(obj))
-                    collectionGenerator.collectionToRegistryExpr(baseDir, obj, linkDependencies, registryURL, callback);
+                    collectionGenerator.collectionToRegistryExpr(baseDir, outputDir, obj, linkDependencies, registryURL, callback);
                 else
-                    packageGenerator.packageObjectToRegistryExpr(baseDir, obj, production, linkDependencies, registryURL, callback);
+                    packageGenerator.packageObjectToRegistryExpr(baseDir, outputDir, obj, production, linkDependencies, registryURL, callback);
             } else {
                 callback("The provided JSON file must be an object or an array");
             }

--- a/lib/packagefetcher/local.js
+++ b/lib/packagefetcher/local.js
@@ -10,15 +10,23 @@ var nijs = require('nijs');
  * reference) from a local directory
  *
  * @param {String} baseDir Directory in which the referrer's package.json configuration resides
+ * @param {String} outputDir Directory in which the nix expression will be written
  * @param {String} versionSpec Version specifier of the Node.js package to fetch, which is a local path in this particular case
  * @param {function(String, Object)} callback Callback function that gets invoked when the work is done.
  *     If some error ocurred, the error parameter is set to contain the error message.
  *     If the operation succeeds, it returns an object with the package configuration and a Nix object that fetches the source
  */
-function fetchMetaDataFromLocalDirectory(baseDir, versionSpec, callback) {
+function fetchMetaDataFromLocalDirectory(baseDir, outputDir, versionSpec, callback) {
     process.stderr.write("fetching local directory: "+versionSpec+" from "+baseDir+"\n");
-    var resolvedPath = path.resolve(baseDir, versionSpec);
     
+    var resolvedPath = path.resolve(baseDir, versionSpec);
+    var first = versionSpec.substr(0, 1);
+    if ( first === '~' || first === '/') {
+        var srcPath = versionSpec;
+    } else {
+        var srcPath = path.relative(outputDir, resolvedPath);
+    }
+
     slasp.sequence([
         function(callback) {
             fs.readFile(path.join(resolvedPath, "package.json"), callback);
@@ -30,7 +38,7 @@ function fetchMetaDataFromLocalDirectory(baseDir, versionSpec, callback) {
             callback(null, {
                 baseDir: resolvedPath,
                 packageObj: packageObj,
-                src: new nijs.NixFile({ value: resolvedPath })
+                src: new nijs.NixFile({ value: srcPath })
             });
         }
     ], callback);

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -34,13 +34,14 @@ function Registry(registryURL, linkDependencies) {
  * Adds a Node.js package and its dependency closure to the registry.
  *
  * @param {String} baseDir Directory in which the referrer's package.json configuration resides
+ * @param {String} outputDir Directory in which generated nix expression will be written
  * @param {String} dependencyName Name of a Node.js package
  * @param {String} versionSpec Version specifier of a Node.js package, which can be an exact version number, version range, URL, or GitHub identifier
  * @param {function(String, String)} callback Callback function that gets invoked when the work is done.
  *     If an error occured, the first parameter is set to the corresponding error message.
  *     If the operation succeeded, the resolved exact version number of the package is returned through the second parameter.
  */
-Registry.prototype.addDependencyClosure = function(baseDir, dependencyName, versionSpec, callback) {
+Registry.prototype.addDependencyClosure = function(baseDir, outputDir, dependencyName, versionSpec, callback) {
 
     if(this.versionSpecCache[dependencyName] === undefined || this.versionSpecCache[dependencyName][versionSpec] === undefined) { // If the resolved version is not cached, fetch it and determine the version
         var self = this;
@@ -65,7 +66,7 @@ Registry.prototype.addDependencyClosure = function(baseDir, dependencyName, vers
                 } else if(versionSpec.match(/^[a-zA-Z0-9]+\/[a-zA-Z0-9]+[#[a-zA-Z0-9]+]?$/)) { // If the version is a GitHub repository, compose the corresponding Git URL and do a Git checkout
                     fetchMetaDataFromGit(dependencyName, "git://github.com/"+versionSpec, callback);
                 } else if(versionSpec.substr(0, 3) == "../" || versionSpec.substr(0, 2) == "~/" || versionSpec.substr(0, 2) == "./" || versionSpec.substr(0, 1) == "/") { // If the version is a path, simply compose a Nix path
-                    fetchMetaDataFromLocalDirectory(baseDir, versionSpec, callback);
+                    fetchMetaDataFromLocalDirectory(baseDir, outputDir, versionSpec, callback);
                 } else { // In all other cases, just try the registry. Sometimes invalid semver ranges are encountered, which have to be processed anyway
                     fetchMetaDataFromNPMRegistry(dependencyName, versionSpec, self.registryURL, callback);
                 }
@@ -83,7 +84,7 @@ Registry.prototype.addDependencyClosure = function(baseDir, dependencyName, vers
                 self.versionSpecCache[dependencyName][versionSpec] = metadata.packageObj.version;
 
                 /* Compose a package out of the retrieved source location and package configuration object */
-                self.addPackage(newBaseDir, metadata.packageObj, metadata.src, true, callback);
+                self.addPackage(newBaseDir, outputDir, metadata.packageObj, metadata.src, true, callback);
             },
             
             function(callback) {
@@ -121,12 +122,13 @@ Registry.prototype.addDependencyClosure = function(baseDir, dependencyName, vers
  * Generates the dependency parameters that are passed to the build function.
  *
  * @param {String} baseDir Directory in which the referrer's package.json configuration resides
+ * @param {String} outputDir Directory in which generated nix expression will be written
  * @param {Object} dependencies An object in which every key represents a package name and each value a version specification.
  * @param {function(String, Object)} callback Callback that gets invoked when the work is done.
  *     If an error occured, the error parameter is set to contain an error message
  *     If the operation succeeded, an object is returned containing references to the dependencies including the version specifiers, actual version numbers and the Nix packages providing them
  */
-Registry.prototype.generateDependencyFunArgs = function(baseDir, dependencies, callback) {
+Registry.prototype.generateDependencyFunArgs = function(baseDir, outputDir, dependencies, callback) {
 
     var self = this;
     
@@ -141,7 +143,7 @@ Registry.prototype.generateDependencyFunArgs = function(baseDir, dependencies, c
             slasp.sequence([
                 /* Add the dependency closures of all dependencies defined in the package configuration */
                 function(callback) {
-                    self.addDependencyClosure(baseDir, dependencyName, versionSpec, callback);
+                    self.addDependencyClosure(baseDir, outputDir, dependencyName, versionSpec, callback);
                 },
                 
                 /* Compose the dependency parameters containing version specifiers, actual version number and Nix packages that implement them  */
@@ -174,12 +176,13 @@ Registry.prototype.generateDependencyFunArgs = function(baseDir, dependencies, c
  * Adds a single package to the registry including all its dependencies.
  *
  * @param {String} baseDir Directory in which the referrer's package.json configuration resides
+ * @param {String} outputDir Directory in which the nix expression will be written
  * @param {Object} packageObj Object representing the Node.js package configuration (typically provided through package.json)
  * @param {Object} src A Nix language object that retrieves the package from a local or external source
  * @param {Boolean} production A boolean that specifies whether to use production development or not. Non-production developments also install all devDependencies.
  * @param {function(String)} callback Callback function that gets invoked when the work is done. The first parameter is set to an error message if some error occured.
  */
-Registry.prototype.addPackage = function(baseDir, packageObj, src, production, callback) {
+Registry.prototype.addPackage = function(baseDir, outputDir, packageObj, src, production, callback) {
 
     var pkgIdentifier = packageObj.name + "-" + packageObj.version;
     
@@ -199,7 +202,7 @@ Registry.prototype.addPackage = function(baseDir, packageObj, src, production, c
         slasp.sequence([
             function(callback) {
                 /* Generate function arguments for the dependencies */
-                self.generateDependencyFunArgs(baseDir, packageObj.dependencies, callback);
+                self.generateDependencyFunArgs(baseDir, outputDir, packageObj.dependencies, callback);
             },
             
             function(callback, dependencies) {
@@ -209,7 +212,7 @@ Registry.prototype.addPackage = function(baseDir, packageObj, src, production, c
                 if(production)
                     callback();
                 else
-                    self.generateDependencyFunArgs(baseDir, packageObj.devDependencies, callback);
+                    self.generateDependencyFunArgs(baseDir, outputDir, packageObj.devDependencies, callback);
             },
             
             function(callback, devDependencies) {


### PR DESCRIPTION
Tweaks to make relative paths work better:

• when recursing into transitive dependencies, use the baseDir of the current module
• generate source paths relative to the nix registry file when the version spec is a relative path
