### PR TITLE
Create node_modules directory on nix-shell

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -286,6 +286,7 @@ let
       inherit nodeDependencies;
       shellHook = stdenv.lib.optionalString (dependencies != []) ''
         export NODE_PATH=$nodeDependencies/lib/node_modules
+        ln -sfT $NODE_PATH node_modules
       '';
     };
 in


### PR DESCRIPTION
Many JS libraries (sadly) depend on node_modules folder to be present (webpack, react-hot-loader etc).

I know that changing the contents on working directory isn't cool. I first tried overriding shellHook, but it isn't overridable currently.

If you don't like this PR, I'll suggest making shellHook derivation overridable, so I can add it without  messing with generated files. 