### PR TITLE
Make shell environment overridable

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -268,7 +268,7 @@ let
         '';
       };
     in
-    stdenv.mkDerivation {
+    stdenv.lib.makeOverridable stdenv.mkDerivation {
       name = "node-shell-${name}-${version}";
       
       buildInputs = [ python nodejs ] ++ stdenv.lib.optional (stdenv.isLinux) utillinux ++ args.buildInputs or [];


### PR DESCRIPTION
I wanted to add some `buildInputs` and override `shellHook` on our shell environment, and without this patch I couldn't.