### PR TITLE
Fix strippedName usage in composePackage

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -6,19 +6,19 @@ let
   # Create a tar wrapper that filters all the 'Ignoring unknown extended header keyword' noise
   tarWrapper = runCommand "tarWrapper" {} ''
     mkdir -p $out/bin
-    
+
     cat > $out/bin/tar <<EOF
     #! ${stdenv.shell} -e
     $(type -p tar) "\$@" --warning=no-unknown-keyword
     EOF
-    
+
     chmod +x $out/bin/tar
   '';
-  
+
   # Function that generates a TGZ file from a NPM project
   buildNodeSourceDist =
     { name, version, src, ... }:
-    
+
     stdenv.mkDerivation {
       name = "node-tarball-${name}-${version}";
       inherit src;
@@ -42,13 +42,13 @@ let
           # Bundle the dependencies of the package
           mkdir -p node_modules
           cd node_modules
-          
+
           # Only include dependencies if they don't exist. They may also be bundled in the package.
           if [ ! -e "${dependency.name}" ]
           then
               ${composePackage dependency}
           fi
-          
+
           cd ..
         ''
       ) dependencies);
@@ -61,13 +61,13 @@ let
         text = ''
           var fs = require('fs');
           var url = require('url');
-          
+
           /*
            * Replaces an impure version specification by *
            */
           function replaceImpureVersionSpec(versionSpec) {
               var parsedUrl = url.parse(versionSpec);
-              
+
               if(versionSpec == "latest" || versionSpec == "unstable" ||
                   versionSpec.substr(0, 2) == ".." || dependency.substr(0, 2) == "./" || dependency.substr(0, 2) == "~/" || dependency.substr(0, 1) == '/')
                   return '*';
@@ -77,9 +77,9 @@ let
               else
                   return versionSpec;
           }
-      
+
           var packageObj = JSON.parse(fs.readFileSync('./package.json'));
-      
+
           /* Replace dependencies */
           if(packageObj.dependencies !== undefined) {
               for(var dependency in packageObj.dependencies) {
@@ -87,7 +87,7 @@ let
                   packageObj.dependencies[dependency] = replaceImpureVersionSpec(versionSpec);
               }
           }
-          
+
           /* Replace development dependencies */
           if(packageObj.devDependencies !== undefined) {
               for(var dependency in packageObj.devDependencies) {
@@ -95,7 +95,7 @@ let
                   packageObj.devDependencies[dependency] = replaceImpureVersionSpec(versionSpec);
               }
           }
-          
+
           /* Replace optional dependencies */
           if(packageObj.optionalDependencies !== undefined) {
               for(var dependency in packageObj.optionalDependencies) {
@@ -103,7 +103,7 @@ let
                   packageObj.optionalDependencies[dependency] = replaceImpureVersionSpec(versionSpec);
               }
           }
-          
+
           /* Write the fixed JSON file */
           fs.writeFileSync("package.json", JSON.stringify(packageObj));
         '';
@@ -112,9 +112,9 @@ let
     ''
       DIR=$(pwd)
       cd $TMPDIR
-      
+
       unpackFile ${src}
-      
+
       # Make the base dir in which the target dependency resides first
       mkdir -p "$(dirname "$DIR/${packageName}")"
 
@@ -122,11 +122,11 @@ let
       then
           # Figure out what directory has been unpacked
           packageDir="$(find . -maxdepth 1 -type d | tail -1)"
-          
+
           # Restore write permissions to make building work
           find "$packageDir" -type d -print0 | xargs -0 chmod u+x
           chmod -R u+w "$packageDir"
-          
+
           # Move the extracted tarball into the output folder
           mv "$packageDir" "$DIR/${packageName}"
       elif [ -d "${src}" ]
@@ -140,19 +140,19 @@ let
 
           # Restore write permissions to make building work
           chmod -R u+w "$strippedName"
-          
+
           # Move the extracted directory into the output folder
           mv "$strippedName" "$DIR/${packageName}"
       fi
 
       # Unset the stripped name to not confuse the next unpack step
       unset strippedName
-      
+
       # Some version specifiers (latest, unstable, URLs, file paths) force NPM to make remote connections or consult paths outside the Nix store.
       # The following JavaScript replaces these by * to prevent that
       cd "$DIR/${packageName}"
       node ${fixImpureDependencies}
-      
+
       # Include the dependencies of the package
       ${includeDependencies { inherit dependencies; }}
       cd ..
@@ -165,36 +165,36 @@ let
     tar --no-same-owner --no-same-permissions -xf ${nodejs.src}
     mv node-* $out
   '';
-  
+
   # Builds and composes an NPM package including all its dependencies
   buildNodePackage = { name, packageName, version, dependencies ? [], production ? true, npmFlags ? "", dontNpmInstall ? false, preRebuild ? "", ... }@args:
-    
+
     stdenv.lib.makeOverridable stdenv.mkDerivation (builtins.removeAttrs args [ "dependencies" ] // {
       name = "node-${name}-${version}";
       buildInputs = [ tarWrapper python nodejs ] ++ stdenv.lib.optional (stdenv.isLinux) utillinux ++ args.buildInputs or [];
       dontStrip = args.dontStrip or true; # Striping may fail a build for some package deployments
-      
+
       inherit dontNpmInstall preRebuild;
-      
+
       unpackPhase = args.unpackPhase or "true";
-      
+
       buildPhase = args.buildPhase or "true";
-      
+
       compositionScript = composePackage args;
       passAsFile = [ "compositionScript" ];
-      
+
       installPhase = args.installPhase or ''
         # Create and enter a root node_modules/ folder
         mkdir -p $out/lib/node_modules
         cd $out/lib/node_modules
-          
+
         # Compose the package and all its dependencies
         source $compositionScriptPath
-        
+
         # Patch the shebangs of the bundled modules to prevent them from
         # calling executables outside the Nix store as much as possible
         patchShebangs .
-        
+
         # Deploy the Node.js package by running npm install. Since the
         # dependencies have been provided already by ourselves, it should not
         # attempt to install them again, which is good, because we want to make
@@ -204,23 +204,23 @@ let
         #
         # The other responsibilities of NPM are kept -- version checks, build
         # steps, postprocessing etc.
-        
+
         export HOME=$TMPDIR
         cd "${packageName}"
         runHook preRebuild
         npm --registry http://www.example.com --nodedir=${nodeSources} ${npmFlags} ${stdenv.lib.optionalString production "--production"} rebuild
-        
+
         if [ "$dontNpmInstall" != "1" ]
         then
             npm --registry http://www.example.com --nodedir=${nodeSources} ${npmFlags} ${stdenv.lib.optionalString production "--production"} install
         fi
-        
+
         # Create symlink to the deployed executable folder, if applicable
         if [ -d "$out/lib/node_modules/.bin" ]
         then
             ln -s $out/lib/node_modules/.bin $out/bin
         fi
-        
+
         # Create symlinks to the deployed manual page folders, if applicable
         if [ -d "$out/lib/node_modules/${packageName}/man" ]
         then
@@ -234,7 +234,7 @@ let
                 done
             done
         fi
-        
+
         # Run post install hook, if provided
         runHook postInstall
       '';
@@ -245,17 +245,17 @@ let
     let
       nodeDependencies = stdenv.mkDerivation {
         name = "node-dependencies-${name}-${version}";
-        
+
         buildInputs = [ tarWrapper python nodejs ] ++ stdenv.lib.optional (stdenv.isLinux) utillinux ++ args.buildInputs or [];
-        
+
         includeScript = includeDependencies { inherit dependencies; };
         passAsFile = [ "includeScript" ];
-        
+
         buildCommand = ''
           mkdir -p $out/lib
           cd $out/lib
           source $includeScriptPath
-          
+
           # Create fake package.json to make the npm commands work properly
           cat > package.json <<EOF
           {
@@ -263,14 +263,14 @@ let
               "version": "${version}"
           }
           EOF
-          
+
           # Patch the shebangs of the bundled modules to prevent them from
           # calling executables outside the Nix store as much as possible
           patchShebangs .
-          
+
           export HOME=$PWD
           npm --registry http://www.example.com --nodedir=${nodeSources} ${npmFlags} ${stdenv.lib.optionalString production "--production"} rebuild
-          
+
           ${stdenv.lib.optionalString (!dontNpmInstall) ''
             npm --registry http://www.example.com --nodedir=${nodeSources} ${npmFlags} ${stdenv.lib.optionalString production "--production"} install
           ''}
@@ -281,7 +281,7 @@ let
     in
     stdenv.lib.makeOverridable stdenv.mkDerivation {
       name = "node-shell-${name}-${version}";
-      
+
       buildInputs = [ python nodejs ] ++ stdenv.lib.optional (stdenv.isLinux) utillinux ++ args.buildInputs or [];
       buildCommand = ''
         mkdir -p $out/bin
@@ -292,7 +292,7 @@ let
         EOF
         chmod +x $out/bin/shell
       '';
-      
+
       # Provide the dependencies in a development shell through the NODE_PATH environment variable
       inherit nodeDependencies;
       shellHook = stdenv.lib.optionalString (dependencies != []) ''

--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -121,7 +121,7 @@ let
       if [ -f "${src}" ]
       then
           # Figure out what directory has been unpacked
-          packageDir=$(find . -maxdepth 1 -type d | tail -1)
+          packageDir="$(find . -maxdepth 1 -type d | tail -1)"
           
           # Restore write permissions to make building work
           find "$packageDir" -type d -print0 | xargs -0 chmod u+x
@@ -131,11 +131,18 @@ let
           mv "$packageDir" "$DIR/${packageName}"
       elif [ -d "${src}" ]
       then
+          # Get a stripped name (without hash) of the source directory.
+          # On old nixpkgs it's already set internally.
+          if [ -z "$strippedName" ]
+          then
+              strippedName="$(stripHash ${src})"
+          fi
+
           # Restore write permissions to make building work
-          chmod -R u+w $strippedName
+          chmod -R u+w "$strippedName"
           
           # Move the extracted directory into the output folder
-          mv $strippedName "$DIR/${packageName}"
+          mv "$strippedName" "$DIR/${packageName}"
       fi
 
       # Unset the stripped name to not confuse the next unpack step


### PR DESCRIPTION
Also does some cleanup. This is because recently `stripHash` stopped to output its results into `strippedName` and instead echoes them (as expected from a Bash function).