### PR TITLE
Remove npm-shrinkwrap.json file when installing a package

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -205,6 +205,9 @@ let
         
         if [ "$dontNpmInstall" != "1" ]
         then
+            # NPM tries to download packages even when they already exist if npm-shrinkwrap is used.
+            rm -f npm-shrinkwrap.json
+
             npm --registry http://www.example.com --nodedir=${nodeSources} ${npmFlags} ${stdenv.lib.optionalString production "--production"} install
         fi
         
@@ -265,6 +268,9 @@ let
           npm --registry http://www.example.com --nodedir=${nodeSources} ${npmFlags} ${stdenv.lib.optionalString production "--production"} rebuild
           
           ${stdenv.lib.optionalString (!dontNpmInstall) ''
+            # NPM tries to download packages even when they already exist if npm-shrinkwrap is used.
+            rm -f npm-shrinkwrap.json
+
             npm --registry http://www.example.com --nodedir=${nodeSources} ${npmFlags} ${stdenv.lib.optionalString production "--production"} install
           ''}
 


### PR DESCRIPTION
For some reason npm tries to download packages even when they are already there and (seemingly) already of required versions when npm-shrinkwrap is used.

This fixes https://github.com/NixOS/nixpkgs/issues/18652. Notice that I have no idea what am I doing! This may be a wrong fix which hides an actual problem somewhere.