### PR TITLE
Use nodejs's version of Python

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -1,8 +1,10 @@
 # This file originates from node2nix
 
-{stdenv, python2, nodejs, utillinux, runCommand, writeTextFile}:
+{stdenv, nodejs, utillinux, runCommand, writeTextFile}:
 
 let
+  inherit (nodejs) python;
+
   # Create a tar wrapper that filters all the 'Ignoring unknown extended header keyword' noise
   tarWrapper = runCommand "tarWrapper" {} ''
     mkdir -p $out/bin
@@ -171,7 +173,7 @@ let
 
     stdenv.lib.makeOverridable stdenv.mkDerivation (builtins.removeAttrs args [ "dependencies" ] // {
       name = "node-${name}-${version}";
-      buildInputs = [ tarWrapper python2 nodejs ] ++ stdenv.lib.optional (stdenv.isLinux) utillinux ++ args.buildInputs or [];
+      buildInputs = [ tarWrapper python nodejs ] ++ stdenv.lib.optional (stdenv.isLinux) utillinux ++ args.buildInputs or [];
       dontStrip = args.dontStrip or true; # Striping may fail a build for some package deployments
 
       inherit dontNpmInstall preRebuild;
@@ -249,7 +251,7 @@ let
       nodeDependencies = stdenv.mkDerivation {
         name = "node-dependencies-${name}-${version}";
 
-        buildInputs = [ tarWrapper python2 nodejs ] ++ stdenv.lib.optional (stdenv.isLinux) utillinux ++ args.buildInputs or [];
+        buildInputs = [ tarWrapper python nodejs ] ++ stdenv.lib.optional (stdenv.isLinux) utillinux ++ args.buildInputs or [];
 
         includeScript = includeDependencies { inherit dependencies; };
         passAsFile = [ "includeScript" ];
@@ -288,7 +290,7 @@ let
     stdenv.lib.makeOverridable stdenv.mkDerivation {
       name = "node-shell-${name}-${version}";
 
-      buildInputs = [ python2 nodejs ] ++ stdenv.lib.optional (stdenv.isLinux) utillinux ++ args.buildInputs or [];
+      buildInputs = [ python nodejs ] ++ stdenv.lib.optional (stdenv.isLinux) utillinux ++ args.buildInputs or [];
       buildCommand = ''
         mkdir -p $out/bin
         cat > $out/bin/shell <<EOF


### PR DESCRIPTION
This backports changes from https://github.com/NixOS/nixpkgs/commit/2de932188080586ec02e2eac4fee1581c38d247b to this repository. cc @FRidh.