### PR TITLE
node-env.nix: support github:owner/repo scheme for package deps

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -73,7 +73,7 @@ let
               if(versionSpec == "latest" || versionSpec == "unstable" ||
                   versionSpec.substr(0, 2) == ".." || dependency.substr(0, 2) == "./" || dependency.substr(0, 2) == "~/" || dependency.substr(0, 1) == '/')
                   return '*';
-              else if(parsedUrl.protocol == "git:" || parsedUrl.protocol == "git+ssh:" || parsedUrl.protocol == "git+http:" || parsedUrl.protocol == "git+https:" ||
+              else if(parsedUrl.protocol == "git:" || parsedUrl.protocol == "git+ssh:" || parsedUrl.protocol == "git+http:" || parsedUrl.protocol == "git+https:" || parsedUrl.protocol == "github:" ||
                   parsedUrl.protocol == "http:" || parsedUrl.protocol == "https:")
                   return '*';
               else


### PR DESCRIPTION
Saw this scheme in use at:

  https://github.com/pump-io/pump.io/blob/v2.1.1/package.json#L23