### PR TITLE
Remove NodeJS 7 Support

### DIFF
--- a/bin/node2nix.js
+++ b/bin/node2nix.js
@@ -17,7 +17,6 @@ var switches = [
     ['-d', '--development', 'Specifies whether to do a development (non-production) deployment for a package.json deployment (false by default)'],
     ['-5', '--nodejs-5', 'Provides all settings to generate expression for usage with Node.js 5.x (default is: Node.js 4.x)'],
     ['-6', '--nodejs-6', 'Provides all settings to generate expression for usage with Node.js 6.x (default is: Node.js 4.x)'],
-    ['-7', '--nodejs-7', 'Provides all settings to generate expression for usage with Node.js 7.x (default is: Node.js 4.x)'],
     ['--supplement-input FILE', 'A supplement package JSON file that are passed as build inputs to all packages defined in the input JSON file'],
     ['--supplement-output FILE', 'Path to a Nix expression representing a supplementing set of Nix packages provided as inputs to a project (defaults to: supplement.nix)'],
     ['--include-peer-dependencies', 'Specifies whether to include peer dependencies. In npm 2.x, this is the default. (false by default)'],
@@ -93,11 +92,6 @@ parser.on('nodejs-5', function(arg, value) {
 parser.on('nodejs-6', function(arg, value) {
     flatten = true;
     nodePackage = "nodejs-6_x";
-});
-
-parser.on('nodejs-7', function(arg, value) {
-    flatten = true;
-    nodePackage = "nodejs-7_x";
 });
 
 parser.on('include-peer-dependencies', function(arg, value) {


### PR DESCRIPTION
NodeJS v7 reached end of life in June 2017, and was removed from
nixpkgs with this commit:

https://github.com/NixOS/nixpkgs/commit/28b0a79c040549afa99900780892d36a7ffe992c#diff-4facf582dc112a917ad60675e0a675c3

--------

Can someone tell me how to run the tests, and I will add it to the readme or if possible add it to scripts in package.js?