### PR TITLE
Ignore all but the last line of output from npm pack

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -27,7 +27,7 @@ let
       buildInputs = [ nodejs ];
       buildPhase = ''
         export HOME=$TMPDIR
-        tgzFile=$(npm pack)
+        tgzFile=$(npm pack | tail -n 1) # Hooks to the pack command will add output (https://docs.npmjs.com/misc/scripts)
       '';
       installPhase = ''
         mkdir -p $out/tarballs


### PR DESCRIPTION
Many scripts are run as hooks to this command
(https://docs.npmjs.com/misc/scripts), adding output which the install phase
will try to mv as files.