### PR TITLE
You have to use ${nodeDependencies} or substitution will not happen

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -531,8 +531,8 @@ let
       # Provide the dependencies in a development shell through the NODE_PATH environment variable
       inherit nodeDependencies;
       shellHook = stdenv.lib.optionalString (dependencies != []) ''
-        export NODE_PATH=$nodeDependencies/lib/node_modules
-        export PATH="$nodeDependencies/bin:$PATH"
+        export NODE_PATH=${nodeDependencies}/lib/node_modules
+        export PATH="${nodeDependencies}/bin:$PATH"
       '';
     };
 in


### PR DESCRIPTION
Signed-off-by: Tim Dysinger <tim@dysinger.net>

This variable ends up appearing verbatim in the shell script. It doesn't get substituted by nix without ${} around it. I think this a typo because the rest of your vars in this file have the proper decorations.
