### PR TITLE
Fix adding x bit on nested directories.

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -72,7 +72,7 @@ let
           packageDir="$(find . -maxdepth 1 -type d | tail -1)"
 
           # Restore write permissions to make building work
-          find "$packageDir" -type d -print0 | xargs -0 chmod u+x
+          find "$packageDir" -type d -exec chmod u+x {} \;
           chmod -R u+w "$packageDir"
 
           # Move the extracted tarball into the output folder


### PR DESCRIPTION
Piping find into xargs doesn't work if there are nested directories (without the 'x' bit set) because find cannot enter the directory until after chmod is executed. This fixes the issue.