### PR TITLE
Use tar --delay-directory-restore to handle some degenerate tar files.

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -11,7 +11,7 @@ let
 
     cat > $out/bin/tar <<EOF
     #! ${stdenv.shell} -e
-    $(type -p tar) "\$@" --warning=no-unknown-keyword
+    $(type -p tar) "\$@" --warning=no-unknown-keyword --delay-directory-restore
     EOF
 
     chmod +x $out/bin/tar


### PR DESCRIPTION
This pull request improves handling of degenerate tar files that seem to be encountered more often in npm packages than in other places.

For a detailed discussion, see https://github.com/NixOS/nixpkgs/pull/50961. Basically, this flag may increase memory consumption when un-tar'ing files, but fixes untarring of some files. Additional discussion here: https://github.com/npm/node-tar/issues/7.

To test this change, create a file.nix with the following contents:
```
{ pkgs ? import <nixpkgs> {} }:
{
  with-delay-dir-shell = (import (pkgs.fetchgit {
    url = "https://github.com/woehr/node2nix";
    rev = "6bb9a26221afcb686a4de6f5b2deb91b1e2ef599";
    sha256 = "0dp69yjjj55nb766p45j1lfygq0vcqcxq5wsyi1z027s62mr5nly";
  }) { inherit pkgs; }).shell;

  node2nix-shell = (import (pkgs.fetchgit {
    url = "https://github.com/svanderburg/node2nix";
    rev = "c876bb8f8749d53ef759de809ce2aa68a8cce20e";
    sha256 = "0zb0yjygmm9glihkhzkax3f223dzqzhpmj25243ygkgzl1pb8sg1";
  }) { inherit pkgs; }).shell;
}
```

Enter each shell with to get access to tarWrapper:
```
nix-shell -A node2nix-shell.nodeDependencies file.nix
[nix-shell:~]$ cat $(which tar)
#! /nix/store/nii7pk6pv4x4as7vsxbvwyzjn67vax6r-bash-4.4-p23/bin/bash -e
/nix/store/2wxinv2k7ih75y7ns5cad9658m68a859-gnutar-1.30/bin/tar "$@" --warning=no-unknown-keyword
```
```
nix-shell -A with-delay-dir-shell.nodeDependencies file.nix
[nix-shell:~]$ cat $(which tar)
#! /nix/store/nii7pk6pv4x4as7vsxbvwyzjn67vax6r-bash-4.4-p23/bin/bash -e
/nix/store/2wxinv2k7ih75y7ns5cad9658m68a859-gnutar-1.30/bin/tar "$@" --warning=no-unknown-keyword --delay-directory-restore
```

vee-validate-2.1.3 is a tarball that exhibits this issue. Try un-tar'ing in each shell.
```
curl -O https://registry.npmjs.org/vee-validate/-/vee-validate-2.1.3.tgz
tar xf vee-validate-2.1.3.tgz
```