### PR TITLE
buildNodePackage: expose nodejs

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -400,6 +400,8 @@ let
         ++ stdenv.lib.optional (stdenv.isDarwin) libtool
         ++ buildInputs;
 
+      inherit nodejs;
+
       inherit dontStrip; # Stripping may fail a build for some package deployments
       inherit dontNpmInstall preRebuild unpackPhase buildPhase;
 


### PR DESCRIPTION
When creating packages with `node2nix -i node-packages.json` we can specify NodeJS version at CLI. However, it is never exposed in Nix, which makes certain inconveniences (I wanted to create another executable node script).

I was able to get `node` executable path inside builder with
```
NODE=$(readlink -f $(which node))
```
but it is less than ideal. The proposed solution allows to change that to
```
# inside builder
$nodejs/bin/node

# from Nix:
"${package.nodejs}/bin/node"
```