### PR TITLE
Add package error context to composePackage

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -57,7 +57,7 @@ let
 
   # Recursively composes the dependencies of a package
   composePackage = { name, packageName, src, dependencies ? [], ... }@args:
-    ''
+    builtins.addErrorContext "while evaluating node package '${packageName}'" ''
       DIR=$(pwd)
       cd $TMPDIR
 


### PR DESCRIPTION
This allows one to figure out which packages are causing evaluation
failures if ran with --show-trace

I just had to debug an evaluation failure, which was impossible without this.

Sidenote: The failure came from a `package-lock.json` file containing `resolved = false` fields, which seems to be [a bug in npm](https://npm.community/t/npm-install-or-npm-update-turns-a-bunch-of-resolved-in-package-lock-json-from-real-values-to-false/3308). This resulted in `fetchurl { url = false; ... }`, resulting in `error: illegal name: '.drv'`. I guess it wouldn't hurt if `fetchurl` gave a better error too, might PR that to nixpkgs.