### PR TITLE
Use HTTPS URL for GitLab

### DIFF
--- a/lib/sources/Source.js
+++ b/lib/sources/Source.js
@@ -56,7 +56,7 @@ Source.constructSource = function(registryURL, baseDir, outputDir, dependencyNam
     } else if(parsedUrl.protocol == "bitbucket:") { // If the version is a Bitbucket repository, compose the corresponding Git URL and do a Git checkout
         return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git://bitbucket.org", parsedUrl));
     } else if(parsedUrl.protocol == "gitlab:") { // If the version is a Gitlab repository, compose the corresponding Git URL and do a Git checkout
-        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git://gitlab.com", parsedUrl));
+        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("https://gitlab.com", parsedUrl));
     } else if(typeof parsedUrl.protocol == "string" && parsedUrl.protocol.substr(0, 3) == "git") { // If the version is a Git URL do a Git checkout
         return new GitSource(baseDir, dependencyName, versionSpec);
     } else if(parsedUrl.protocol == "http:" || parsedUrl.protocol == "https:") { // If the version is an HTTP URL do a download


### PR DESCRIPTION
Unauthenticated git:// protocol doesn't work on GitLab.com. See https://gitlab.com/gitlab-com/support-forum/issues/3225. Fixes #157.