### PR TITLE
Add support for nixpkgs's nodejs-13_x packageset.

### DIFF
--- a/bin/node2nix.js
+++ b/bin/node2nix.js
@@ -19,6 +19,9 @@ var switches = [
     ['-4', '--nodejs-4', 'Provides all settings to generate expression for usage with Node.js 4.x (default is: Node.js 8.x)'],
     ['-6', '--nodejs-6', 'Provides all settings to generate expression for usage with Node.js 6.x (default is: Node.js 8.x)'],
     ['-8', '--nodejs-8', 'Provides all settings to generate expression for usage with Node.js 8.x (default is: Node.js 8.x)'],
+    ['-10', '--nodejs-10', 'Provides all settings to generate expression for usage with Node.js 10.x (default is: Node.js 8.x)'],
+    ['-12', '--nodejs-12', 'Provides all settings to generate expression for usage with Node.js 12.x (default is: Node.js 8.x)'],
+    ['-13', '--nodejs-13', 'Provides all settings to generate expression for usage with Node.js 13.x (default is: Node.js 8.x)'],
     ['--nodejs-10', 'Provides all settings to generate expression for usage with Node.js 10.x (default is: Node.js 8.x)'],
     ['--nodejs-12', 'Provides all settings to generate expression for usage with Node.js 12.x (default is: Node.js 8.x)'],
     ['--supplement-input FILE', 'A supplement package JSON file that are passed as build inputs to all packages defined in the input JSON file'],
@@ -130,6 +133,12 @@ parser.on('nodejs-10', function(arg, value) {
 parser.on('nodejs-12', function(arg, value) {
     flatten = true;
     nodePackage = "nodejs-12_x";
+    bypassCache = true;
+});
+
+parser.on('nodejs-13', function(arg, value) {
+    flatten = true;
+    nodePackage = "nodejs-13_x";
     bypassCache = true;
 });
 

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-8_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-10_x"}:
 
 let
   nodeEnv = import ./nix/node-env.nix {


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/71799 introduced the `nodejs-13_x` package set support in Nixpkgs. We forgot to update `node2nix` in the process, hence this PR.

Tested this change in a local nixpkgs checkout with

`../result/bin/node2nix --nodejs-13 -i node-packages-v13.json -o node-packages-v13.nix -c composition-v13.nix `. The resulting files are correct.

Also: `nodejs-8_x` has been removed from the current nixpkgs master. Updating
the default nodejs package to `nodejs-10_x` in `default.nix`.
