### PR TITLE
node-env.nix: make it work with set -u

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -363,7 +363,7 @@ let
 
         npm ${forceOfflineFlag} --nodedir=${nodeSources} ${npmFlags} ${stdenv.lib.optionalString production "--production"} rebuild
 
-        if [ "$dontNpmInstall" != "1" ]
+        if [ "''${dontNpmInstall-}" != "1" ]
         then
             # NPM tries to download packages even when they already exist if npm-shrinkwrap is used.
             rm -f npm-shrinkwrap.json


### PR DESCRIPTION
In nixpkgs master we check for undefined variables now.
Also see: https://github.com/NixOS/nixpkgs/pull/79410/files#r376299414