### PR TITLE
Log when name error is found

### DIFF
--- a/lib/sources/Source.js
+++ b/lib/sources/Source.js
@@ -121,6 +121,9 @@ Source.prototype.convertIntegrityStringToNixHash = function(integrity) {
  * @see NixASTNode#toNixAST
  */
 Source.prototype.toNixAST = function() {
+    if(!this.config.name){
+      console.log("name is missing:", this.config);
+    }
     return {
         name: this.config.name.replace("@", "_at_").replace("/", "_slash_"), // Escape characters from scoped package names that aren't allowed
         packageName: this.config.name,


### PR DESCRIPTION
I recently learned that when using a custom `.json` file for `node2nix` a missing name is reported as an error. However, if there is also a `package.json` with no name, we get the old error. 

- package.json // no name
- node2nix.json // has name and version

```bash
node2nix -i node2nix.json
```

results in 

```bash
name: this.config.name.replace("@", "_at_").replace("/", "_slash_"), // Escape characters from scoped package names that aren't allowed
```

This leads me to believe that the `config.name` undefined error is just not limited so limited. This PR adds more logging so that when this error occurs for yet unknown reasons, it's easier to debug.