### PR TITLE
Fail early on empty npm package

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -71,6 +71,13 @@ let
           # Figure out what directory has been unpacked
           packageDir="$(find . -maxdepth 1 -type d | tail -1)"
 
+          if [ "$packageDir" == "." ]; then
+              echo "error: npm tarball did not contain any folders."
+              echo "It should contain a single folder with a package.json file inside."
+              echo "See also: https://docs.npmjs.com/cli/publish"
+              exit 1
+          fi
+
           # Restore write permissions to make building work
           find "$packageDir" -type d -exec chmod u+x {} \;
           chmod -R u+w "$packageDir"


### PR DESCRIPTION
Without this check the error is a bit obscure:

    unpacking source archive /nix/store/mhwh5gdybaad4pswlbq7laqg7hx34f4s-mastodon-bot-1.0.1.tgz
    mv: refusing to remove '.' or '..' directory: skipping '.'
    builder for '/nix/store/9zbllma0r4wf8l29jp0arig9b7vvg2a5-node_mastodon-bot-1.0.1.drv' failed with exit code 1