### PR TITLE
Make nodeDependencies depend only on package.json/package-lock.json

### DIFF
--- a/lib/expressions/CompositionExpression.js
+++ b/lib/expressions/CompositionExpression.js
@@ -133,6 +133,8 @@ CompositionExpression.prototype.toNixAST = function() {
                 funExpr: new nijs.NixImport(new nijs.NixFile({ value: this.packagesNixPath })),
                 paramExpr: {
                     fetchurl: new nijs.NixInherit("pkgs"),
+                    "nix-gitignore": new nijs.NixInherit("pkgs"),
+                    stdenv: new nijs.NixInherit("pkgs"),
                     fetchgit: fetchgitAttr,
                     nodeEnv: new nijs.NixInherit(),
                     globalBuildInputs: globalBuildInputs ? new nijs.NixInherit() : undefined

--- a/lib/expressions/OutputExpression.js
+++ b/lib/expressions/OutputExpression.js
@@ -39,6 +39,8 @@ OutputExpression.prototype.toNixAST = function() {
             nodeEnv: undefined,
             fetchurl: undefined,
             fetchgit: undefined,
+            "nix-gitignore": undefined,
+            stdenv: undefined,
             globalBuildInputs: []
         },
         body: new nijs.NixLet({

--- a/lib/expressions/PackageExpression.js
+++ b/lib/expressions/PackageExpression.js
@@ -82,7 +82,29 @@ PackageExpression.prototype.toNixAST = function() {
                 attrSetExpr: new nijs.NixExpression("nodeEnv"),
                 refExpr: new nijs.NixExpression("buildNodeDependencies")
             }),
-            paramExpr: new nijs.NixExpression("args")
+            paramExpr: new nijs.NixFunInvocation({
+                funExpr: new nijs.NixFunInvocation({
+                    funExpr: new nijs.NixExpression("stdenv.lib.overrideExisting"),
+                    paramExpr: new nijs.NixExpression("args")
+                }),
+                paramExpr: {
+                    src: new nijs.NixFunInvocation({
+                        funExpr: new nijs.NixExpression("stdenv.mkDerivation"),
+                        paramExpr: {
+                            name: new nijs.NixExpression('args.name + "-package-json"'),
+                            src: new nijs.NixFunInvocation({
+                                funExpr: new nijs.NixFunInvocation({
+                                    funExpr: new nijs.NixExpression("nix-gitignore.gitignoreSourcePure"),
+                                    paramExpr: ["*", "!package.json", "!package-lock.json"]
+                                }),
+                                paramExpr: new nijs.NixExpression("args.src")
+                            }),
+                            dontBuild: true,
+                            installPhase: "mkdir -p $out; cp -r ./* $out;"
+                        }
+                    })
+                }
+            })
         })
     };
 


### PR DESCRIPTION
This follows on my previous PR #199. In this PR, I override the `src` field for `nodeDependencies` so that it only depends on `package.json` and `package-lock.json`, if present. Thus, the dependencies don't have to be rebuilt unless there's a change to these two files. 

This works well for my use-case, where I generate the dependencies separately and then symlink them into my own derivation to build my app. This follows a suggestion from #74 and is a partial solution to that issue. 

I think this is a clear win for the `buildNodeDependencies` export. Whether it should also be used with `buildNodeShell`, `buildNodePackage`, etc. is less clear. It would speed up builds significantly and fix #74, but the discussion there mentions that symlinking `node_modules` might not always work. (For example, in the presence of native dependencies and the `--preserve-symlinks` flag.) I think something like this is definitely called for to fully fix #74 though. Maybe separately build and symlink `node_modules` by default and add a flag to go back to the old behavior for the (hopefully rare) cases where it doesn't work?

EDIT: or, to sidestep symlinking issues, why not always build dependencies separately and then `cp -r` them?