### PR TITLE
Set default meta.platforms of nodePackages to Node.js platforms

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -391,10 +391,11 @@ let
     , dontStrip ? true
     , unpackPhase ? "true"
     , buildPhase ? "true"
+    , meta ? {}
     , ... }@args:
 
     let
-      extraArgs = removeAttrs args [ "name" "dependencies" "buildInputs" "dontStrip" "dontNpmInstall" "preRebuild" "unpackPhase" "buildPhase" ];
+      extraArgs = removeAttrs args [ "name" "dependencies" "buildInputs" "dontStrip" "dontNpmInstall" "preRebuild" "unpackPhase" "buildPhase" "meta" ];
     in
     stdenv.mkDerivation ({
       name = "node_${name}-${version}";
@@ -446,6 +447,11 @@ let
         # Run post install hook, if provided
         runHook postInstall
       '';
+
+      meta = {
+        # default to Node.js' platforms
+        platforms = nodejs.meta.platforms;
+      } // meta;
     } // extraArgs);
 
   # Builds a node environment (a node_modules folder and a set of binaries)


### PR DESCRIPTION
Keeping an empty platforms, causes to hydra to avoid caching in certain
platforms like darwin.