### PR TITLE
Add support for package aliases

### DIFF
--- a/lib/sources/NPMRegistrySource.js
+++ b/lib/sources/NPMRegistrySource.js
@@ -58,6 +58,20 @@ inherit(Source, NPMRegistrySource);
  */
 NPMRegistrySource.prototype.fetch = function(callback) {
     var self = this;
+    var spec = {
+        name: self.dependencyName,
+        versionSpec: self.versionSpec,
+    };
+
+    var aliasParser = self.versionSpec.match(/^npm:(.*)@(.*)$/);
+    if (aliasParser !== null) {
+        self.dependencyName = aliasParser[1];
+        self.versionSpec = aliasParser[2];
+    } else if (self.versionSpec.startsWith("npm:")) {
+        aliasParser = self.versionSpec.match(/^npm:(.*)$/);
+        self.dependencyName = aliasParser[1];
+        self.versionSpec = "";
+    }
 
     if(self.versionSpec == "") // An empty versionSpec translates to *
         self.versionSpec = "*";
@@ -117,10 +131,11 @@ NPMRegistrySource.prototype.fetch = function(callback) {
             var resolvedVersion = semver.maxSatisfying(versionIdentifiers, version, true);
 
             if(resolvedVersion === null) {
-                callback("Cannot resolve version: "+ self.dependencyName + "@" + version);
+                callback("Cannot resolve version: "+ spec.name + "@" + spec.versionSpec);
             } else {
                 self.config = result.versions[resolvedVersion];
-                self.identifier = self.config.name + "-" + self.config.version;
+                self.config.name = spec.name;
+                self.identifier = spec.name + "-" + self.config.version;
 
                 if(self.stripOptionalDependencies && self.config.optionalDependencies !== undefined && self.config.dependencies !== undefined) {
                     /*


### PR DESCRIPTION
Adds support for the following dependency specifier:

> `npm install <alias>@npm:<name>`

https://docs.npmjs.com/cli/v7/commands/npm-install
