### PR TITLE
add aarch64-darwin support

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,5 @@
 { nixpkgs ? <nixpkgs>
-, systems ? [ "i686-linux" "x86_64-linux" "x86_64-darwin" ]
+, systems ? [ "i686-linux" "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ]
 }:
 
 let


### PR DESCRIPTION
Tested the build with: `nix-build release.nix -A package.aarch64-darwin` and it works.