### PR TITLE
Fix #253: exclude peerDependencies by default even using '--lock' flag

### DIFF
--- a/lib/Package.js
+++ b/lib/Package.js
@@ -231,6 +231,8 @@ Package.prototype.resolveDependenciesFromLockedDependencies = function(dependenc
                 callback();
             } else if(self.deploymentConfig.stripOptionalDependencies && dependency.optional) { // When the stripping optional dependencies feature has been enabled, remove all optional dependencies
                 callback();
+            } else if (!self.deploymentConfig.includePeerDependencies && dependency.peer) { // When the including peer dependencies features has been disabled, remove all peer dependencies
+                callback();
             } else if(self.production && dependency.dev) { // Development dependencies should not be included in production mode
                 callback();
             } else {


### PR DESCRIPTION
Fixes #253.
- `peerDependencies` are not included by default
- setting `--include-peer-dependencies` makes node2nix works as previous default