### PR TITLE
Fix check for existing scoped packages

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -49,7 +49,7 @@ let
           cd node_modules
 
           # Only include dependencies if they don't exist. They may also be bundled in the package.
-          if [ ! -e "${dependency.name}" ]
+          if [ ! -e "${dependency.packageName}" ]
           then
               ${composePackage dependency}
           fi


### PR DESCRIPTION
When installing a package into node_modules the compositionScript
checks to see if the package already exists. However, it uses the
wrong attribute and checks an unrelated path in the case of scoped
packages.

Example Before:

    if [ ! -e "_at_engoo_slash_mnoga" ]

Example After

    if [ ! -e "@engoo/mnoga" ]