### PR TITLE
Fix indent in node-env.nix

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -246,8 +246,8 @@ let
           var packageLock = JSON.parse(fs.readFileSync("./package-lock.json"));
 
           if(![1, 2].includes(packageLock.lockfileVersion)) {
-             process.stderr.write("Sorry, I only understand lock file versions 1 and 2!\n");
-             process.exit(1);
+            process.stderr.write("Sorry, I only understand lock file versions 1 and 2!\n");
+            process.exit(1);
           }
 
           if(packageLock.dependencies !== undefined) {


### PR DESCRIPTION
This is motivated by my git commit not succeeding:



```
> git commit -m "Add [...]"
0 / 6 have been reformatted
[...]/node-env.nix:
        251: Wrong amount of left-padding spaces(want multiple of 2)
        252: Wrong amount of left-padding spaces(want multiple of 2)

2 errors found

Code is not aligned with .editorconfig
Review the output and commit your fixes
```