### PR TITLE
Add a second call to patchShebangs to

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -377,6 +377,9 @@ let
 
         npm ${forceOfflineFlag} --nodedir=${nodeSources} ${npmFlags} ${lib.optionalString production "--production"} rebuild
 
+        ## The previous command may add additional executable scripts that need to be patched.
+        patchShebangs .
+
         if [ "''${dontNpmInstall-}" != "1" ]
         then
             # NPM tries to download packages even when they already exist if npm-shrinkwrap is used.


### PR DESCRIPTION
The call to `npm rebuild` can bring in additional executable scripts
which need to be patched as well.

This relates to issue #184