### PR TITLE
Patch shebangs in dependency binaries

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 
 let
   nodeEnv = import ./nix/node-env.nix {
-    inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
+    inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript jq;
     inherit pkgs nodejs;
     libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
   };

--- a/lib/expressions/CompositionExpression.js
+++ b/lib/expressions/CompositionExpression.js
@@ -129,6 +129,7 @@ CompositionExpression.prototype.toNixAST = function() {
                         runCommand: new nijs.NixInherit("pkgs"),
                         writeTextFile: new nijs.NixInherit("pkgs"),
                         writeShellScript: new nijs.NixInherit("pkgs"),
+                        jq: new nijs.NixInherit("pkgs"),
                         pkgs: new nijs.NixInherit(),
                         nodejs: new nijs.NixInherit()
                     }

--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -493,6 +493,7 @@ let
     , dontNpmInstall ? false
     , bypassCache ? false
     , reconstructLock ? false
+    , preRebuild ? ""
     , dontStrip ? true
     , unpackPhase ? "true"
     , buildPhase ? "true"
@@ -510,7 +511,7 @@ let
           ++ buildInputs;
 
         inherit dontStrip; # Stripping may fail a build for some package deployments
-        inherit dontNpmInstall unpackPhase buildPhase;
+        inherit dontNpmInstall preRebuild unpackPhase buildPhase;
 
         includeScript = includeDependencies { inherit dependencies; };
         pinpointDependenciesScript = pinpointDependenciesOfPackage args;


### PR DESCRIPTION
I needed to do this so that a call to `node-gyp-build` would work in one of my dependencies. 

Sometimes a dependency comes with an executable script, which ultimately gets symlinked into `node_modules/.bin`. The existing `patchShebangs` call at the beginning of `prepareAndInvokeNPM` doesn't always catch these, because they don't always have the executable bit set. As a result, you get a failure in the Nix build because `/usr/bin/env node` doesn't exist.

So, this PR uses `jq` to traverse the `bin` field of `package.json`, turning these files executable and patching them as necessary.

This PR also exposes the `preRebuild` hook for `buildNodeDependencies`, and by extension for the `shell` attribute. I think this will resolve #226.