### PR TITLE
Flakeify node2nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1634782485,
+        "narHash": "sha256-psfh4OQSokGXG0lpq3zKFbhOo3QfoeudRcaUnwMRkQo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "34ad3ffe08adfca17fcb4e4a47bb5f3b113687be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A very basic flake";
+  description = "Generate Nix expressions to build NPM packages";
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "A very basic flake";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        inherit (import ./default.nix { inherit pkgs; })
+          sources package shell nodeDependencies;
+        node2nix = package;
+        app = flake-utils.lib.mkApp { drv = package; };
+      in {
+        packages.node2nix = node2nix;
+        defaultPackage = node2nix;
+        apps.node2nix = app;
+        defaultApp = app;
+        nodeDependencies = nodeDependencies;
+        nodeShell = shell;
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,10 @@
         inherit (import ./default.nix { inherit pkgs; })
           sources package shell nodeDependencies;
         node2nix = package;
-        app = flake-utils.lib.mkApp { drv = package; };
+        app = flake-utils.lib.mkApp {
+          drv = package;
+          exePath = "/bin/node2nix";
+        };
       in {
         packages.node2nix = node2nix;
         defaultPackage = node2nix;

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
           drv = package;
           exePath = "/bin/node2nix";
         };
+        overlays = final: prev: { node2nix = node2nix; };
       in {
         packages.node2nix = node2nix;
         defaultPackage = node2nix;
@@ -22,5 +23,6 @@
         defaultApp = app;
         nodeDependencies = nodeDependencies;
         nodeShell = shell;
+        inherit overlays;
       });
 }


### PR DESCRIPTION
Add a `flake.nix` and `flake.lock` file so that `node2nix` can be used/addressed as a Nix Flake.