### PR TITLE
Use HTTPS URL for GitHub

### DIFF
--- a/lib/sources/Source.js
+++ b/lib/sources/Source.js
@@ -50,7 +50,7 @@ Source.constructSource = function(registries, baseDir, outputDir, dependencyName
     if(parsedVersionSpec !== null) { // If the version is valid semver range, fetch the package from the NPM registry
         return new NPMRegistrySource(baseDir, dependencyName, parsedVersionSpec, registries, stripOptionalDependencies);
     } else if(parsedUrl.protocol == "github:") { // If the version is a GitHub repository, compose the corresponding Git URL and do a Git checkout
-        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git://github.com", parsedUrl));
+        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("https://github.com", parsedUrl));
     } else if(parsedUrl.protocol == "gist:") { // If the version is a GitHub gist repository, compose the corresponding Git URL and do a Git checkout
         return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("https://gist.github.com", parsedUrl));
     } else if(parsedUrl.protocol == "bitbucket:") { // If the version is a Bitbucket repository, compose the corresponding Git URL and do a Git checkout


### PR DESCRIPTION
Unauthenticated git:// protocol doesn't work on GitHub. See
https://github.blog/2021-09-01-improving-git-protocol-security-github