### PR TITLE
Reject invalid command-line options

### DIFF
--- a/bin/node2nix.js
+++ b/bin/node2nix.js
@@ -65,6 +65,11 @@ var executable;
 
 /* Define process rules for option parameters */
 
+parser.on(function(arg, value) {
+    process.stderr.write("node2nix: " + arg + ": invalid option\n");
+    process.exit(1);
+})
+
 parser.on('help', function(arg, value) {
     help = true;
 });

--- a/tests/cli/default.nix
+++ b/tests/cli/default.nix
@@ -22,6 +22,9 @@ simpleTest {
       )
       machine.succeed("chmod u+w testprojects")
 
+      # Try to use an invalid option. This should fail.
+      machine.fail("cd testprojects/complete; node2nix --invalid-option")
+
       # Try to generate Nix expressions for a package.json with no name. This should fail.
       machine.fail("cd testprojects/noname; node2nix")
 


### PR DESCRIPTION
Currently, `node2nix` accepts and silently ignores invalid options, which is confusing.