### PR TITLE
Use git+https:// protocol for HTTPS git URLs

### DIFF
--- a/lib/sources/Source.js
+++ b/lib/sources/Source.js
@@ -50,19 +50,19 @@ Source.constructSource = function(registries, baseDir, outputDir, dependencyName
     if(parsedVersionSpec !== null) { // If the version is valid semver range, fetch the package from the NPM registry
         return new NPMRegistrySource(baseDir, dependencyName, parsedVersionSpec, registries, stripOptionalDependencies);
     } else if(parsedUrl.protocol == "github:") { // If the version is a GitHub repository, compose the corresponding Git URL and do a Git checkout
-        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("https://github.com", parsedUrl));
+        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git+https://github.com", parsedUrl));
     } else if(parsedUrl.protocol == "gist:") { // If the version is a GitHub gist repository, compose the corresponding Git URL and do a Git checkout
-        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("https://gist.github.com", parsedUrl));
+        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git+https://gist.github.com", parsedUrl));
     } else if(parsedUrl.protocol == "bitbucket:") { // If the version is a Bitbucket repository, compose the corresponding Git URL and do a Git checkout
         return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git://bitbucket.org", parsedUrl));
     } else if(parsedUrl.protocol == "gitlab:") { // If the version is a Gitlab repository, compose the corresponding Git URL and do a Git checkout
-        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("https://gitlab.com", parsedUrl));
+        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git+https://gitlab.com", parsedUrl));
     } else if(typeof parsedUrl.protocol == "string" && parsedUrl.protocol.substr(0, 3) == "git") { // If the version is a Git URL do a Git checkout
         return new GitSource(baseDir, dependencyName, versionSpec);
     } else if(parsedUrl.protocol == "http:" || parsedUrl.protocol == "https:") { // If the version is an HTTP URL do a download
         return new HTTPSource(baseDir, dependencyName, versionSpec);
     } else if(versionSpec.match(/^[a-zA-Z0-9_\-]+\/[a-zA-Z0-9\.]+([#[a-zA-Z0-9_\-]|pull\/[0-9]+\/[a-zA-Z0-9\.]+[#[a-zA-Z0-9_\-]+)+]?$/)) { // If the version is a GitHub repository, compose the corresponding Git URL and do a Git checkout
-        return new GitSource(baseDir, dependencyName, "git://github.com/"+versionSpec);
+        return new GitSource(baseDir, dependencyName, "git+https://github.com/"+versionSpec);
     } else if(parsedUrl.protocol == "file:") { // If the version is a file URL, simply compose a Nix path
         return new LocalSource(baseDir, dependencyName, outputDir, parsedUrl.path);
     } else if(versionSpec.substr(0, 3) == "../" || versionSpec.substr(0, 2) == "~/" || versionSpec.substr(0, 2) == "./" || versionSpec.substr(0, 1) == "/") { // If the version is a path, simply compose a Nix path

--- a/lib/sources/Source.js
+++ b/lib/sources/Source.js
@@ -54,7 +54,7 @@ Source.constructSource = function(registries, baseDir, outputDir, dependencyName
     } else if(parsedUrl.protocol == "gist:") { // If the version is a GitHub gist repository, compose the corresponding Git URL and do a Git checkout
         return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git+https://gist.github.com", parsedUrl));
     } else if(parsedUrl.protocol == "bitbucket:") { // If the version is a Bitbucket repository, compose the corresponding Git URL and do a Git checkout
-        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git://bitbucket.org", parsedUrl));
+        return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git+https://bitbucket.org", parsedUrl));
     } else if(parsedUrl.protocol == "gitlab:") { // If the version is a Gitlab repository, compose the corresponding Git URL and do a Git checkout
         return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git+https://gitlab.com", parsedUrl));
     } else if(typeof parsedUrl.protocol == "string" && parsedUrl.protocol.substr(0, 3) == "git") { // If the version is a Git URL do a Git checkout


### PR DESCRIPTION
I encountered issues on Jan 11th last week during the [GitHub git:// protocol brownout](https://github.blog/2021-09-01-improving-git-protocol-security-github) due to the version spec `github:jean-emmanuel/bonjour` in [open-stage-control](https://github.com/jean-emmanuel/open-stage-control) being fetched as `git://github.com/jean-emmanuel/bonjour` rather than `https://github.com/jean-emmanuel/bonjour`. I traced it back to the URL getting rewritten to `https://github.com/jean-emmanuel/bonjour` by [Source.js](https://github.com/svanderburg/node2nix/blob/0deb18a/lib/sources/Source.js#L52-L53) but then subsequently rewritten while fetching to `git://github.com/jean-emmanuel/bonjour` by [GitSource.js](https://github.com/svanderburg/node2nix/blob/0deb18a/lib/sources/GitSource.js#L56-L69) as an unknown protocol (since it expects `git+https://` [like NPM does](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#git-urls-as-dependencies))

This PR updates the URL rewriting for `github:`, `gist:`, `gitlab:`, and GitHub repository version spec formats to use `git+https://` URLs instead of `https://` (or `git://`) URLs to fix this. This expands on the change in svanderburg/node2nix#269 which seems to have been incomplete

To reproduce the issue, you can generate a node-packages.nix file from the following package.json and see that it generates the wrong output with the current 1.10.0 version of node2nix:

package.json

```json
{
  "name": "test-node2nix",
  "version": "0.0.0",
  "dependencies": {
    "bonjour": "github:jean-emmanuel/bonjour"
  }
}
```

node-packages.nix

```nix
# This file has been generated by node2nix 1.10.0. Do not edit!

{nodeEnv, fetchurl, fetchgit, nix-gitignore, stdenv, lib, globalBuildInputs ? []}:

let
  sources = {
# [...snip...]
    "bonjour-https://github.com/jean-emmanuel/bonjour" = {
      name = "bonjour";
      packageName = "bonjour";
      version = "4.0.0";
      src = fetchgit {
        url = "git://github.com/jean-emmanuel/bonjour";      # <-------- ISSUE HERE
        rev = "33d7fa28c568d05cb7ffda1fd2b20f4cc364e273";
        sha256 = "3f9cd813a3cd8ac6ec02421bd590922a4722a0dd89416dc580df6ee1f34e48b0";
      };
    };
# [...snip...]
```