### PR TITLE
docs: Use nodeDependencies instead of shell.nodeDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Here's an example derivation showing this technique:
 
 ```nix
 let
-  nodeDependencies = (pkgs.callPackage ./default.nix {}).shell.nodeDependencies;
+  nodeDependencies = (pkgs.callPackage ./default.nix {}).nodeDependencies;
 in
 
 stdenv.mkDerivation {


### PR DESCRIPTION
The only difference between `shell.nodeDependencies` and `nodeDependencies` in this example is that `shell.nodeDependencies` skips https://github.com/svanderburg/node2nix/pull/205 - but in the example given I think it's most likely that people only want the dependencies to depend on package{,-lock}.json.

This was introduced in https://github.com/svanderburg/node2nix/pull/218.