### PR TITLE
Upgrade default Node.js version to 14.x

### DIFF
--- a/bin/node2nix.js
+++ b/bin/node2nix.js
@@ -17,14 +17,14 @@ var switches = [
     ['-e', '--node-env FILE', 'Path to the Nix expression implementing functions that builds NPM packages (defaults to: node-env.nix)'],
     ['-l', '--lock FILE', 'Path to the package-lock.json file that pinpoints the variants of all dependencies'],
     ['-d', '--development', 'Specifies whether to do a development (non-production) deployment for a package.json deployment (false by default)'],
-    ['-4', '--nodejs-4', 'Provides all settings to generate expression for usage with Node.js 4.x (default is: Node.js 12.x)'],
-    ['-6', '--nodejs-6', 'Provides all settings to generate expression for usage with Node.js 6.x (default is: Node.js 12.x)'],
-    ['-8', '--nodejs-8', 'Provides all settings to generate expression for usage with Node.js 8.x (default is: Node.js 12.x)'],
-    ['-10', '--nodejs-10', 'Provides all settings to generate expression for usage with Node.js 10.x (default is: Node.js 12.x)'],
-    ['-12', '--nodejs-12', 'Provides all settings to generate expression for usage with Node.js 12.x (default is: Node.js 12.x)'],
-    ['-13', '--nodejs-13', 'Provides all settings to generate expression for usage with Node.js 13.x (default is: Node.js 12.x)'],
-    ['-14', '--nodejs-14', 'Provides all settings to generate expression for usage with Node.js 14.x (default is: Node.js 12.x)'],
-    ['-16', '--nodejs-16', 'Provides all settings to generate expression for usage with Node.js 16.x (default is: Node.js 12.x)'],
+    ['-4', '--nodejs-4', 'Provides all settings to generate expression for usage with Node.js 4.x (default is: nodejs-14_x)'],
+    ['-6', '--nodejs-6', 'Provides all settings to generate expression for usage with Node.js 6.x (default is: nodejs-14_x)'],
+    ['-8', '--nodejs-8', 'Provides all settings to generate expression for usage with Node.js 8.x (default is: nodejs-14_x)'],
+    ['-10', '--nodejs-10', 'Provides all settings to generate expression for usage with Node.js 10.x (default is: nodejs-14_x)'],
+    ['-12', '--nodejs-12', 'Provides all settings to generate expression for usage with Node.js 12.x (default is: nodejs-14_x)'],
+    ['-13', '--nodejs-13', 'Provides all settings to generate expression for usage with Node.js 13.x (default is: nodejs-14_x)'],
+    ['-14', '--nodejs-14', 'Provides all settings to generate expression for usage with Node.js 14.x (default is: nodejs-14_x)'],
+    ['-16', '--nodejs-16', 'Provides all settings to generate expression for usage with Node.js 16.x (default is: nodejs-14_x)'],
     ['--supplement-input FILE', 'A supplement package JSON file that are passed as build inputs to all packages defined in the input JSON file'],
     ['--supplement-output FILE', 'Path to a Nix expression representing a supplementing set of Nix packages provided as inputs to a project (defaults to: supplement.nix)'],
     ['--include-peer-dependencies', 'Specifies whether to include peer dependencies. In npm 2.x, this is the default. (false by default)'],
@@ -56,7 +56,7 @@ var supplementNix = "supplement.nix";
 var nodeEnvNix = "node-env.nix";
 var lockJSON;
 var registries = [];
-var nodePackage = "nodejs-12_x";
+var nodePackage = "nodejs-14_x";
 var noCopyNodeEnv = false;
 var bypassCache = true;
 var useFetchGitPrivate = false;

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-12_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-14_x"}:
 
 let
   nodeEnv = import ./nix/node-env.nix {


### PR DESCRIPTION
Node.js 12.x has reached End-of-Life (https://nodejs.org/en/about/releases/) , so I think it would be good to switch default Node.js version to `nodejs-14_x`.
Thank you.
