### PR TITLE
Add nodejs-18 option

### DIFF
--- a/bin/node2nix.js
+++ b/bin/node2nix.js
@@ -25,6 +25,7 @@ var switches = [
     ['-13', '--nodejs-13', 'Provides all settings to generate expression for usage with Node.js 13.x (default is: nodejs-14_x)'],
     ['-14', '--nodejs-14', 'Provides all settings to generate expression for usage with Node.js 14.x (default is: nodejs-14_x)'],
     ['-16', '--nodejs-16', 'Provides all settings to generate expression for usage with Node.js 16.x (default is: nodejs-14_x)'],
+    ['-18', '--nodejs-18', 'Provides all settings to generate expression for usage with Node.js 18.x (default is: nodejs-14_x)'],
     ['--supplement-input FILE', 'A supplement package JSON file that are passed as build inputs to all packages defined in the input JSON file'],
     ['--supplement-output FILE', 'Path to a Nix expression representing a supplementing set of Nix packages provided as inputs to a project (defaults to: supplement.nix)'],
     ['--include-peer-dependencies', 'Specifies whether to include peer dependencies. In npm 2.x, this is the default. (false by default)'],
@@ -165,6 +166,12 @@ parser.on('nodejs-16', function(arg, value) {
 parser.on('nodejs-17', function(arg, value) {
     flatten = true;
     nodePackage = "nodejs-17_x";
+    bypassCache = true;
+});
+
+parser.on('nodejs-18', function(arg, value) {
+    flatten = true;
+    nodePackage = "nodejs-18_x";
     bypassCache = true;
 });
 


### PR DESCRIPTION
This PR adds support for Node.js 18.x, just like the former versions. Some packages now require 18, so this can be important to some users.