### PR TITLE
Convert CRLF for script bin files

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -530,12 +530,15 @@ let
         then
             ln -s $out/lib/node_modules/.bin $out/bin
 
-            # Patch the shebang lines of all the executables
+            # Fixup all executables
             ls $out/bin/* | while read i
             do
                 file="$(readlink -f "$i")"
                 chmod u+rwx "$file"
-                patchShebangs "$file"
+                if isScript "$file"
+                then
+                    sed -i 's/\r$//' "$file"  # convert crlf to lf
+                fi
             done
         fi
 


### PR DESCRIPTION
After we started generating our own bin links in #302, we did not provide the line-ending normalization that npm did

This PR corrects that to have similar behavior to before for packages with CRLF line-endings