### PR TITLE
Strip optional peer dependencies, remove support for NodeJS before v14 and add v20/v21

### DIFF
--- a/bin/node2nix.js
+++ b/bin/node2nix.js
@@ -26,6 +26,7 @@ var switches = [
     ['-14', '--nodejs-14', 'Provides all settings to generate expression for usage with Node.js 14.x (default is: nodejs-14_x)'],
     ['-16', '--nodejs-16', 'Provides all settings to generate expression for usage with Node.js 16.x (default is: nodejs-14_x)'],
     ['-18', '--nodejs-18', 'Provides all settings to generate expression for usage with Node.js 18.x (default is: nodejs-14_x)'],
+    ['-20', '--nodejs-20', 'Provides all settings to generate expression for usage with Node.js 20.x (default is: nodejs-14_x)'],
     ['--supplement-input FILE', 'A supplement package JSON file that are passed as build inputs to all packages defined in the input JSON file'],
     ['--supplement-output FILE', 'Path to a Nix expression representing a supplementing set of Nix packages provided as inputs to a project (defaults to: supplement.nix)'],
     ['--include-peer-dependencies', 'Specifies whether to include peer dependencies. In npm 2.x, this is the default. (true by default for Node.js 16+)'],
@@ -183,6 +184,13 @@ parser.on('nodejs-18', function(arg, value) {
     nodePackage = "nodejs-18_x";
     bypassCache = true;
     includePeerDependencies = true;
+});
+
+parser.on('nodejs-20', function(arg, value) {
+  flatten = true;
+  nodePackage = "nodejs_20";
+  bypassCache = true;
+  includePeerDependencies = true;
 });
 
 parser.on('include-peer-dependencies', function(arg, value) {

--- a/bin/node2nix.js
+++ b/bin/node2nix.js
@@ -17,11 +17,11 @@ var switches = [
     ['-e', '--node-env FILE', 'Path to the Nix expression implementing functions that builds NPM packages (defaults to: node-env.nix)'],
     ['-l', '--lock FILE', 'Path to the package-lock.json file that pinpoints the variants of all dependencies'],
     ['-d', '--development', 'Specifies whether to do a development (non-production) deployment for a package.json deployment (false by default)'],
-    ['-14', '--nodejs-14', 'Provides all settings to generate expression for usage with Node.js 14.x (default is: nodejs_14)'],
-    ['-16', '--nodejs-16', 'Provides all settings to generate expression for usage with Node.js 16.x (default is: nodejs_14)'],
-    ['-18', '--nodejs-18', 'Provides all settings to generate expression for usage with Node.js 18.x (default is: nodejs_14)'],
-    ['-20', '--nodejs-20', 'Provides all settings to generate expression for usage with Node.js 20.x (default is: nodejs_14)'],
-    ['-21', '--nodejs-21', 'Provides all settings to generate expression for usage with Node.js 21.x (default is: nodejs_14)'],
+    ['-14', '--nodejs-14', 'Provides all settings to generate expression for usage with Node.js 14.x (default is: nodejs_18)'],
+    ['-16', '--nodejs-16', 'Provides all settings to generate expression for usage with Node.js 16.x (default is: nodejs_18)'],
+    ['-18', '--nodejs-18', 'Provides all settings to generate expression for usage with Node.js 18.x (default is: nodejs_18)'],
+    ['-20', '--nodejs-20', 'Provides all settings to generate expression for usage with Node.js 20.x (default is: nodejs_18)'],
+    ['-21', '--nodejs-21', 'Provides all settings to generate expression for usage with Node.js 21.x (default is: nodejs_18)'],
     ['--supplement-input FILE', 'A supplement package JSON file that are passed as build inputs to all packages defined in the input JSON file'],
     ['--supplement-output FILE', 'Path to a Nix expression representing a supplementing set of Nix packages provided as inputs to a project (defaults to: supplement.nix)'],
     ['--include-peer-dependencies', 'Specifies whether to include peer dependencies. In npm 2.x, this is the default. (true by default for Node.js 16+)'],
@@ -53,7 +53,7 @@ var supplementNix = "supplement.nix";
 var nodeEnvNix = "node-env.nix";
 var lockJSON;
 var registries = [];
-var nodePackage = "nodejs_14";
+var nodePackage = "nodejs_18";
 var noCopyNodeEnv = false;
 var bypassCache = true;
 var useFetchGitPrivate = false;

--- a/bin/node2nix.js
+++ b/bin/node2nix.js
@@ -17,10 +17,10 @@ var switches = [
     ['-e', '--node-env FILE', 'Path to the Nix expression implementing functions that builds NPM packages (defaults to: node-env.nix)'],
     ['-l', '--lock FILE', 'Path to the package-lock.json file that pinpoints the variants of all dependencies'],
     ['-d', '--development', 'Specifies whether to do a development (non-production) deployment for a package.json deployment (false by default)'],
-    ['-14', '--nodejs-14', 'Provides all settings to generate expression for usage with Node.js 14.x (default is: nodejs-14_x)'],
-    ['-16', '--nodejs-16', 'Provides all settings to generate expression for usage with Node.js 16.x (default is: nodejs-14_x)'],
-    ['-18', '--nodejs-18', 'Provides all settings to generate expression for usage with Node.js 18.x (default is: nodejs-14_x)'],
-    ['-20', '--nodejs-20', 'Provides all settings to generate expression for usage with Node.js 20.x (default is: nodejs-14_x)'],
+    ['-14', '--nodejs-14', 'Provides all settings to generate expression for usage with Node.js 14.x (default is: nodejs_14)'],
+    ['-16', '--nodejs-16', 'Provides all settings to generate expression for usage with Node.js 16.x (default is: nodejs_14)'],
+    ['-18', '--nodejs-18', 'Provides all settings to generate expression for usage with Node.js 18.x (default is: nodejs_14)'],
+    ['-20', '--nodejs-20', 'Provides all settings to generate expression for usage with Node.js 20.x (default is: nodejs_14)'],
     ['--supplement-input FILE', 'A supplement package JSON file that are passed as build inputs to all packages defined in the input JSON file'],
     ['--supplement-output FILE', 'Path to a Nix expression representing a supplementing set of Nix packages provided as inputs to a project (defaults to: supplement.nix)'],
     ['--include-peer-dependencies', 'Specifies whether to include peer dependencies. In npm 2.x, this is the default. (true by default for Node.js 16+)'],
@@ -52,7 +52,7 @@ var supplementNix = "supplement.nix";
 var nodeEnvNix = "node-env.nix";
 var lockJSON;
 var registries = [];
-var nodePackage = "nodejs-14_x";
+var nodePackage = "nodejs_14";
 var noCopyNodeEnv = false;
 var bypassCache = true;
 var useFetchGitPrivate = false;
@@ -112,21 +112,21 @@ parser.on('development', function(arg, value) {
 
 parser.on('nodejs-14', function(arg, value) {
     flatten = true;
-    nodePackage = "nodejs-14_x";
+    nodePackage = "nodejs_14";
     bypassCache = true;
     includePeerDependencies = false;
 });
 
 parser.on('nodejs-16', function(arg, value) {
     flatten = true;
-    nodePackage = "nodejs-16_x";
+    nodePackage = "nodejs_16";
     bypassCache = true;
     includePeerDependencies = true;
 });
 
 parser.on('nodejs-18', function(arg, value) {
     flatten = true;
-    nodePackage = "nodejs-18_x";
+    nodePackage = "nodejs_18";
     bypassCache = true;
     includePeerDependencies = true;
 });

--- a/bin/node2nix.js
+++ b/bin/node2nix.js
@@ -17,12 +17,6 @@ var switches = [
     ['-e', '--node-env FILE', 'Path to the Nix expression implementing functions that builds NPM packages (defaults to: node-env.nix)'],
     ['-l', '--lock FILE', 'Path to the package-lock.json file that pinpoints the variants of all dependencies'],
     ['-d', '--development', 'Specifies whether to do a development (non-production) deployment for a package.json deployment (false by default)'],
-    ['-4', '--nodejs-4', 'Provides all settings to generate expression for usage with Node.js 4.x (default is: nodejs-14_x)'],
-    ['-6', '--nodejs-6', 'Provides all settings to generate expression for usage with Node.js 6.x (default is: nodejs-14_x)'],
-    ['-8', '--nodejs-8', 'Provides all settings to generate expression for usage with Node.js 8.x (default is: nodejs-14_x)'],
-    ['-10', '--nodejs-10', 'Provides all settings to generate expression for usage with Node.js 10.x (default is: nodejs-14_x)'],
-    ['-12', '--nodejs-12', 'Provides all settings to generate expression for usage with Node.js 12.x (default is: nodejs-14_x)'],
-    ['-13', '--nodejs-13', 'Provides all settings to generate expression for usage with Node.js 13.x (default is: nodejs-14_x)'],
     ['-14', '--nodejs-14', 'Provides all settings to generate expression for usage with Node.js 14.x (default is: nodejs-14_x)'],
     ['-16', '--nodejs-16', 'Provides all settings to generate expression for usage with Node.js 16.x (default is: nodejs-14_x)'],
     ['-18', '--nodejs-18', 'Provides all settings to generate expression for usage with Node.js 18.x (default is: nodejs-14_x)'],
@@ -116,48 +110,6 @@ parser.on('development', function(arg, value) {
     production = false;
 });
 
-parser.on('nodejs-4', function(arg, value) {
-    flatten = false;
-    nodePackage = "nodejs-4_x";
-    bypassCache = false;
-    includePeerDependencies = false;
-});
-
-parser.on('nodejs-6', function(arg, value) {
-    flatten = true;
-    nodePackage = "nodejs-6_x";
-    bypassCache = false;
-    includePeerDependencies = false;
-});
-
-parser.on('nodejs-8', function(arg, value) {
-    flatten = true;
-    nodePackage = "nodejs-8_x";
-    bypassCache = true;
-    includePeerDependencies = false;
-});
-
-parser.on('nodejs-10', function(arg, value) {
-    flatten = true;
-    nodePackage = "nodejs-10_x";
-    bypassCache = true;
-    includePeerDependencies = false;
-});
-
-parser.on('nodejs-12', function(arg, value) {
-    flatten = true;
-    nodePackage = "nodejs-12_x";
-    bypassCache = true;
-    includePeerDependencies = false;
-});
-
-parser.on('nodejs-13', function(arg, value) {
-    flatten = true;
-    nodePackage = "nodejs-13_x";
-    bypassCache = true;
-    includePeerDependencies = false;
-});
-
 parser.on('nodejs-14', function(arg, value) {
     flatten = true;
     nodePackage = "nodejs-14_x";
@@ -168,13 +120,6 @@ parser.on('nodejs-14', function(arg, value) {
 parser.on('nodejs-16', function(arg, value) {
     flatten = true;
     nodePackage = "nodejs-16_x";
-    bypassCache = true;
-    includePeerDependencies = true;
-});
-
-parser.on('nodejs-17', function(arg, value) {
-    flatten = true;
-    nodePackage = "nodejs-17_x";
     bypassCache = true;
     includePeerDependencies = true;
 });

--- a/bin/node2nix.js
+++ b/bin/node2nix.js
@@ -21,6 +21,7 @@ var switches = [
     ['-16', '--nodejs-16', 'Provides all settings to generate expression for usage with Node.js 16.x (default is: nodejs_14)'],
     ['-18', '--nodejs-18', 'Provides all settings to generate expression for usage with Node.js 18.x (default is: nodejs_14)'],
     ['-20', '--nodejs-20', 'Provides all settings to generate expression for usage with Node.js 20.x (default is: nodejs_14)'],
+    ['-21', '--nodejs-21', 'Provides all settings to generate expression for usage with Node.js 21.x (default is: nodejs_14)'],
     ['--supplement-input FILE', 'A supplement package JSON file that are passed as build inputs to all packages defined in the input JSON file'],
     ['--supplement-output FILE', 'Path to a Nix expression representing a supplementing set of Nix packages provided as inputs to a project (defaults to: supplement.nix)'],
     ['--include-peer-dependencies', 'Specifies whether to include peer dependencies. In npm 2.x, this is the default. (true by default for Node.js 16+)'],
@@ -138,8 +139,15 @@ parser.on('nodejs-20', function(arg, value) {
   includePeerDependencies = true;
 });
 
+parser.on('nodejs-21', function(arg, value) {
+  flatten = true;
+  nodePackage = "nodejs_21";
+  bypassCache = true;
+  includePeerDependencies = true;
+});
+
 parser.on('include-peer-dependencies', function(arg, value) {
-    includePeerDependencies = true;
+  includePeerDependencies = true;
 });
 
 parser.on('no-flatten', function(arg, value) {

--- a/lib/sources/NPMRegistrySource.js
+++ b/lib/sources/NPMRegistrySource.js
@@ -156,6 +156,14 @@ NPMRegistrySource.prototype.fetch = function(callback) {
                     }
                 }
 
+                if(self.stripOptionalDependencies && self.config.peerDependencies !== undefined && self.config.peerDependenciesMeta !== undefined) {
+                    for (var dependencyName in self.config.peerDependencies) {
+                        if (self.config.peerDependenciesMeta[dependencyName] && self.config.peerDependenciesMeta[dependencyName]?.optional) {
+                            delete self.config.peerDependencies[dependencyName];
+                        }
+                    }
+                }
+
                 // Determine the output hash. If the package provides an integrity string, use it to compose a hash. Otherwise fall back to sha1
 
                 if(self.config.dist.integrity !== undefined) {


### PR DESCRIPTION
Originally I just wanted to add support for [stripping optional peer dependencies](https://github.com/svanderburg/node2nix/issues/316) but then I also removed support for all NodeJS versions before 14 since they are not present in Nixpkgs for current NixOS, added support for NodeJS 20/21 and changed default NodeJS version to 18