### PR TITLE
Fix `Source.constructSource` to use versionSpec instead of parsedVersionSpec

### DIFF
--- a/lib/sources/Source.js
+++ b/lib/sources/Source.js
@@ -44,12 +44,9 @@ Source.constructSource = function(registries, baseDir, outputDir, dependencyName
     var LocalSource = require('./LocalSource.js').LocalSource;
     var NPMRegistrySource = require('./NPMRegistrySource.js').NPMRegistrySource;
 
-    var parsedVersionSpec = semver.validRange(versionSpec, true);
     var parsedUrl = url.parse(versionSpec);
 
-    if(parsedVersionSpec !== null) { // If the version is valid semver range, fetch the package from the NPM registry
-        return new NPMRegistrySource(baseDir, dependencyName, parsedVersionSpec, registries, stripOptionalDependencies);
-    } else if(parsedUrl.protocol == "github:") { // If the version is a GitHub repository, compose the corresponding Git URL and do a Git checkout
+    if(parsedUrl.protocol == "github:") { // If the version is a GitHub repository, compose the corresponding Git URL and do a Git checkout
         return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git+https://github.com", parsedUrl));
     } else if(parsedUrl.protocol == "gist:") { // If the version is a GitHub gist repository, compose the corresponding Git URL and do a Git checkout
         return new GitSource(baseDir, dependencyName, GitSource.composeGitURL("git+https://gist.github.com", parsedUrl));
@@ -67,7 +64,9 @@ Source.constructSource = function(registries, baseDir, outputDir, dependencyName
         return new LocalSource(baseDir, dependencyName, outputDir, parsedUrl.path);
     } else if(versionSpec.substr(0, 3) == "../" || versionSpec.substr(0, 2) == "~/" || versionSpec.substr(0, 2) == "./" || versionSpec.substr(0, 1) == "/") { // If the version is a path, simply compose a Nix path
         return new LocalSource(baseDir, dependencyName, outputDir, versionSpec);
-    } else { // In all other cases, just try the registry. Sometimes invalid semver ranges are encountered or a tag has been provided (e.g. 'latest', 'unstable')
+    } else {
+        // In all other cases (valid or invalid semver range), just try the registry.
+        // Sometimes invalid semver ranges are encountered or a tag has been provided (e.g. 'latest', 'unstable')
         return new NPMRegistrySource(baseDir, dependencyName, versionSpec, registries, stripOptionalDependencies);
     }
 };

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -22,5 +22,6 @@
   "node-libcurl",
   "libxmljs",
   { "bcrypt": "3.0.x" },
-  { "next": "npm:@blitzjs/next@10.2.3-0.37.0" }
+  { "next": "npm:@blitzjs/next@10.2.3-0.37.0" },
+  { "abcd": "npm:@codingame/monaco-vscode-api@ >= 1.69.0 < 1.70.0" }
 ]


### PR DESCRIPTION
Previously, `parsedVersionSpec` was passed to `NPMRegistrySource.prototype.fetch` which stripped the alias if the versionSpec also contained a semver range, like `npm:@codingame/monaco-vscode-api@ >= 1.69.0 < 1.70.0`.

This change removes the semver parsing from `Source.constructSource` as it is the rensponsibility of `NPMRegistrySource.prototype.fetch`.

Fixes #331 