### PR TITLE
Make node2nix work with recent nixpkgs

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -4,7 +4,7 @@
 
 let
   # Workaround to cope with utillinux in Nixpkgs 20.09 and util-linux in Nixpkgs master
-  utillinux = if pkgs ? utillinux then pkgs.utillinux else pkgs.util-linux;
+  utillinux = if pkgs ? util-linux then pkgs.util-linux else pkgs.utillinux;
 
   python = if nodejs ? python then nodejs.python else python2;
 


### PR DESCRIPTION
`pkgs.util-linux` existence must be considered first to avoid panicking when the `pkgs.utillinux` is converted into a `throw`.

Even though `node2nix` is [being phased out](https://github.com/NixOS/nixpkgs/issues/229475), some people might use it in the meantime.